### PR TITLE
Add Project.toml, drop support for old versions of Julia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "Destruct"
+uuid = "dde75ccc-4946-507f-85f2-ccadd28c929c"
+authors = ["Samuel Palato <samuel.palato@mail.mcgill.ca>"]
+version = "1.1.0"
+
+[deps]
+
+[compat]
+julia = "1"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Random"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.6 2-
-Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Destruct
-using Compat.Test
-using Compat.Random
-import Compat.rand
+using Test
+using Random
+import Random.rand
 
 rand(rng::AbstractRNG, T::Type{String}) = randstring(rng)
 types = [Int32, Float64, Complex{Float64}, Bool]


### PR DESCRIPTION
Currently, the project compat range excludes the most recent version of Compat (v3), for reasons I do not understand. Instead of figuring out the cause of this problem, I figured it might makes sense to drop support for old versions of Julia since it's been a while since Julia 1.0 was released and the project is fairly stable. People using older versions of Julia will still be able to use the v1.1 version.

I have also added a Project.toml file, since REQUIRE has been deprecated.