### PR TITLE
Tag new version (v1.1.1) to capture removed compat dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Destruct"
 uuid = "dde75ccc-4946-507f-85f2-ccadd28c929c"
 authors = ["Samuel Palato <samuel.palato@mail.mcgill.ca>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 


### PR DESCRIPTION
To make #4 visible to Pkg, a new version must be tagged.