### PR TITLE
Add tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,12 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds the workflow for [TagBot](https://github.com/marketplace/actions/julia-tagbot) which automatically tags new versions of Julia packages. If you decided to tag a new version (e.g. v1.1.1 in #5 if you think it's justified), you will need to add [Registrator GitHub App](https://github.com/JuliaRegistries/Registrator.jl#via-the-github-app) to this repo, then follow the instructions there to tag a new version. Once you've done that, this github workflow should automatically create a new git tag and add it to the repo.